### PR TITLE
Optimizations

### DIFF
--- a/src/siphash.cr
+++ b/src/siphash.cr
@@ -22,7 +22,7 @@ module SipHash
         h.digest str
     end
 
-    class Hash
+    struct Hash
         def initialize(k0 : UInt64, k1 : UInt64)
             @v0 = k0 ^ 0x736f6d6570736575_u64
             @v1 = k1 ^ 0x646f72616e646f6d_u64
@@ -32,10 +32,10 @@ module SipHash
 
         # Returns the 64-bit SipHash-2-4
         def digest(msg : String)
-            digest msg.bytes
+            digest Slice.new(msg.to_unsafe, msg.bytesize)
         end
 
-        def digest(msg : Array(UInt8))
+        def digest(msg : Slice(UInt8) | Array(UInt8))
             len = msg.length
             iter = len / 8
 


### PR DESCRIPTION
Hi there!

This is a small but nice and very well written project. I send here some optimizations for fun :-)
1. Instead of using `String#bytes`, which allocates an Array, I use a slice to the string's bytes. This would be considered unsafe, but since we are only reading from the slice it's OK and harmless (and much more efficient)
2. Because the Hash type is only created in the `digest` method and is not returned nor shared, it can be declared as a struct. This means memory is allocated on the stack. It's still mutable, but because we are not sharing it there's no issue.

I have the following benchmark:

``` crystal
# foo.cr
require "./src/siphash"

time = Time.now
a = 0
10_000_000.times do
  a += SipHash.digest(0, 0, "12345678123")
end
puts Time.now - time
puts a
```

Doing `crystal foo.cr --release` I get:
- Before: 00:00:02.1190970
- After: 00:00:00.0004710

;-)
